### PR TITLE
RFC: Support for exceptions with cake > 3.3 middleware

### DIFF
--- a/src/Middleware/NewRelicErrorHandlerMiddleware.php
+++ b/src/Middleware/NewRelicErrorHandlerMiddleware.php
@@ -1,0 +1,22 @@
+<?php
+namespace NewRelic\Middleware;
+
+use Cake\Error\Middleware\ErrorHandlerMiddleware;
+use NewRelic\Lib\NewRelic;
+
+/**
+ * {@inheritDoc}
+ */
+class NewRelicErrorHandlerMiddleware extends ErrorHandlerMiddleware
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function handleException($exception, $request, $response)
+    {
+        NewRelic::collect();
+        NewRelic::sendException($exception);
+
+        return parent::handleException($exception, $request, $response);
+    }
+}


### PR DESCRIPTION
Not sure what you think of this? We have it internally in our app but might share it even though it's very short. 

At least it gives people an idea on how to solve it if they see no exceptions with middleware - so maybe it should rather be a code snippet in the readme describing you can do this?