### PR TITLE
Allow for PHP7+ errors

### DIFF
--- a/src/Lib/NewRelic.php
+++ b/src/Lib/NewRelic.php
@@ -216,10 +216,10 @@ class NewRelic {
 /**
  * Send an exception to New Relic
  *
- * @param  Exception $exception
+ * @param  Exception|Throwable $exception
  * @return void
  */
-    public static function sendException(Exception $exception) {
+    public static function sendException($exception) {
         if (!static::hasNewRelic()) {
             return;
         }


### PR DESCRIPTION
PHP7 errors/throwables cause a fatal error when calling `NewRelic::sendException`. Fix that.