### PR TITLE
Use the plugin as the most important grouping mechanism

### DIFF
--- a/src/Traits/NewRelicTrait.php
+++ b/src/Traits/NewRelicTrait.php
@@ -195,13 +195,13 @@ trait NewRelicTrait {
  */
 	protected function _deriveNameFromRequest(Request $request) {
 		$name = [];
+		
+		if ($request->getParam('plugin')) {
+			$name[] = $request->getParam('plugin');
+		}		
 
 		if ($request->getParam('prefix')) {
 			$name[] = $request->getParam('prefix');
-		}
-
-		if ($request->getParam('plugin')) {
-			$name[] = $request->getParam('plugin');
 		}
 
 		$name[] = $request->getParam('controller');


### PR DESCRIPTION
As plugins can contain multiple prefixes, right now with these 2 urls:

```
Plugin: Api
Prefix: Users
Controller: Actions
Action: index
```


```
Plugin: Api
Prefix: Posts
Controller: Comments
Action: index
```

Would become:

`/Users/Api/Actions/index` and `/Posts/Api/Comments/index`

But I see having multiple plugins, with same prefixes in as a quit normal use case - so one could have 2 plugins with `Api` prefix in it, and now the grouping is what I would consider wrong.


```
Plugin: Forum
Prefix: Api
Controller: Posts
Action: index
```


```
Plugin: Admin
Prefix: Api
Controller: Posts
Action: index
```

Will be grouped as `Api/Forum/Posts/index` and `/Api/Admin/Posts/index` 🤔

I think the better ones would be `Forum/Api/Posts/index` and `Admin/Api/Posts/index`

EDIT: Note, this will change the transaction names in NewRelic - so I would consider this BC breaking